### PR TITLE
Update url username matching to match regex allowed by Django

### DIFF
--- a/relationships/urls.py
+++ b/relationships/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls.defaults import *
 
 urlpatterns = patterns('relationships.views',
     url(r'^$', 'relationship_redirect', name='relationship_list_base'),
-    url(r'^(?P<username>[\w-]+)/(?:(?P<status_slug>[\w-]+)/)?$', 'relationship_list', name='relationship_list'),
-    url(r'^add/(?P<username>[\w-]+)/(?P<status_slug>[\w-]+)/$', 'relationship_handler', {'add': True}, name='relationship_add'),
-    url(r'^remove/(?P<username>[\w-]+)/(?P<status_slug>[\w-]+)/$', 'relationship_handler', {'add': False}, name='relationship_remove'),
+    url(r'^(?P<username>[\w.@+-]+)/(?:(?P<status_slug>[\w-]+)/)?$', 'relationship_list', name='relationship_list'),
+    url(r'^add/(?P<username>[\w.@+-]+)/(?P<status_slug>[\w-]+)/$', 'relationship_handler', {'add': True}, name='relationship_add'),
+    url(r'^remove/(?P<username>[\w.@+-]+)/(?P<status_slug>[\w-]+)/$', 'relationship_handler', {'add': False}, name='relationship_remove'),
 )


### PR DESCRIPTION
Starting with Django 1.2 the default [`UserCreationForm`](https://code.djangoproject.com/browser/django/tags/releases/1.2/django/contrib/auth/forms.py#L14) validation for usernames was expanded to include @.+-_ characters. However the regular expressions for matching the usernames within this project only allow for letters, numbers, underscore (_) and the dash (-) character. This allows for created users which cannot be followed using the default url patterns. According [RFC3986](http://www.ietf.org/rfc/rfc3986.txt) the url path segment may contain unreserved / pct-encoded / sub-delims / ":" / "@" characters. This change updates the url patterns to be inline with the Django UserCreationForm.
