### PR TITLE
bugfix for py3 on raise

### DIFF
--- a/relationships/templatetags/relationship_tags.py
+++ b/relationships/templatetags/relationship_tags.py
@@ -62,8 +62,7 @@ def if_relationship(parser, token):
     """
     bits = list(token.split_contents())
     if len(bits) != 4:
-        raise TemplateSyntaxError, "%r takes 3 arguments:\n%s" % \
-            (bits[0], if_relationship.__doc__)
+        raise TemplateSyntaxError("%r takes 3 arguments:\n%s" % (bits[0], if_relationship.__doc__))
     end_tag = 'end' + bits[0]
     nodelist_true = parser.parse(('else', end_tag))
     token = parser.next_token()


### PR DESCRIPTION
when running django-relationships on py3 environment this bug occurs on template tags uses
