### PR TITLE
Don't override UserAdmin for custom auth model

### DIFF
--- a/relationships/admin.py
+++ b/relationships/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User as DefaultUserModel
 
 from .compat import User
 from .forms import RelationshipStatusAdminForm
@@ -13,13 +14,19 @@ class RelationshipInline(admin.TabularInline):
     fk_name = 'from_user'
 
 
-class UserRelationshipAdmin(UserAdmin):
+class UserRelationshipAdminMixin(object):
     inlines = (RelationshipInline,)
 
 
 class RelationshipStatusAdmin(admin.ModelAdmin):
     form = RelationshipStatusAdminForm
 
-admin.site.unregister(User)
-admin.site.register(User, UserRelationshipAdmin)
+
+if User == DefaultUserModel:
+    class UserRelationshipAdmin(UserRelationshipAdminMixin, UserAdmin):
+        pass
+
+    admin.site.unregister(User)
+    admin.site.register(User, UserRelationshipAdmin)
+
 admin.site.register(RelationshipStatus, RelationshipStatusAdmin)


### PR DESCRIPTION
Since Django doesn't register a custom user model with admin by default, `admin.site.unregister(User)` would fail. Instead, we can provide two things - a mixin to add to custom user admin, and override default admin if there is no custom user model. 

There's still a conflict if there are multiple libraries trying to override `UserAdmin`, but that's out of scope for this PR.